### PR TITLE
Add an option to enable/disable background blur at app launch

### DIFF
--- a/quickstep/src/com/android/launcher3/QuickstepTransitionManager.java
+++ b/quickstep/src/com/android/launcher3/QuickstepTransitionManager.java
@@ -84,6 +84,7 @@ import android.graphics.Point;
 import android.graphics.PointF;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.graphics.RenderEffect;
 import android.graphics.drawable.Drawable;
 import android.os.Handler;
 import android.os.IBinder;
@@ -275,7 +276,7 @@ public class QuickstepTransitionManager implements OnDeviceProfileChangeListener
     // Will never be larger than MAX_NUM_TASKS
     private LinkedHashMap<Integer, Pair<Integer, Integer>> mTaskStartParams;
     private boolean mAreAnimationsEnabled = true;
-
+    private boolean mBlurBackgroundAtAppLaunch = true;
     private final Interpolator mOpeningXInterpolator;
     private final Interpolator mOpeningInterpolator;
 
@@ -895,11 +896,13 @@ public class QuickstepTransitionManager implements OnDeviceProfileChangeListener
         appAnimator.addUpdateListener(listener);
         // Since we added a start delay, call update here to init the FloatingIconView properly.
         listener.onUpdate(0, true /* initOnly */);
-
+        mBlurBackgroundAtAppLaunch = Utilities.blurBackgroundAtAppLaunch(mLauncher.getApplicationContext());
         // If app targets are translucent, do not animate the background as it causes a visible
         // flicker when it resets itself at the end of its animation.
         if (appTargetsAreTranslucent || !launcherClosing) {
             animatorSet.play(appAnimator);
+        } else if (mBlurBackgroundAtAppLaunch) {
+            animatorSet.playTogether(appAnimator, getBackgroundBlurAnimator());
         } else {
             animatorSet.playTogether(appAnimator, getBackgroundAnimator());
         }
@@ -1035,11 +1038,13 @@ public class QuickstepTransitionManager implements OnDeviceProfileChangeListener
                 surfaceApplier.scheduleApply(transaction);
             }
         });
-
+        mBlurBackgroundAtAppLaunch = Utilities.blurBackgroundAtAppLaunch(mLauncher.getApplicationContext());
         // If app targets are translucent, do not animate the background as it causes a visible
         // flicker when it resets itself at the end of its animation.
         if (appTargetsAreTranslucent || !launcherClosing) {
             animatorSet.play(appAnimator);
+        } else if (mBlurBackgroundAtAppLaunch) {
+            animatorSet.playTogether(appAnimator, getBackgroundBlurAnimator());
         } else {
             animatorSet.playTogether(appAnimator, getBackgroundAnimator());
         }
@@ -1093,7 +1098,84 @@ public class QuickstepTransitionManager implements OnDeviceProfileChangeListener
 
         return backgroundRadiusAnim;
     }
+    private ObjectAnimator getBackgroundBlurAnimator() {
+        boolean allowBlurringLauncher = mLauncher.getStateManager().getState() != OVERVIEW
+                && BlurUtils.supportsBlursOnWindows();
 
+        LaunchDepthController depthController = new LaunchDepthController(mLauncher);
+        ObjectAnimator backgroundRadiusAnim = ObjectAnimator.ofFloat(depthController.stateDepth,
+                        MULTI_PROPERTY_VALUE, BACKGROUND_APP.getDepth(mLauncher))
+                .setDuration(APP_LAUNCH_DURATION);
+
+        if (allowBlurringLauncher) {
+            View rootView = mLauncher.getDragLayer();
+
+            // Create a composite SurfaceControl layer for everything behind the app animation
+            ViewRootImpl viewRootImpl = rootView.getViewRootImpl();
+            SurfaceControl parentSurface = viewRootImpl != null ? viewRootImpl.getSurfaceControl() : null;
+
+            if (parentSurface != null) {
+                SurfaceControl blurLayer = new SurfaceControl.Builder()
+                        .setName("Blur Layer")
+                        .setParent(parentSurface)
+                        .setOpaque(false)
+                        .setEffectLayer()
+                        .build();
+
+                SurfaceControl.Transaction transaction = new SurfaceControl.Transaction();
+
+                // Create an animator for the blur effect
+                backgroundRadiusAnim.addUpdateListener(animation -> {
+
+                    if (mLauncher.getStateManager().getState() == LauncherState.ALL_APPS) {
+                        return;
+                    }
+                    float maxBlurRadius = Utilities.getBlurRadius(mLauncher.getApplicationContext());
+                    float animatedValue = (float) animation.getAnimatedValue();
+                    float blurRadius = Math.min(maxBlurRadius, animatedValue * maxBlurRadius); // Scale blur with animation progress
+
+                    // Dynamically update blur radius
+                    if (blurLayer != null && blurLayer.isValid()) {
+                        transaction.setBackgroundBlurRadius(blurLayer, (int) blurRadius);
+                        transaction.setAlpha(blurLayer, 1f);
+                        transaction.show(blurLayer);
+                        transaction.apply();
+                    }
+                });
+
+                backgroundRadiusAnim.setInterpolator(mOpeningInterpolator);
+
+                // Cleanup on animation end or cancel
+                backgroundRadiusAnim.addListener(new AnimatorListenerAdapter() {
+                    @Override
+                    public void onAnimationEnd(Animator animation) {
+                        cleanupBlurLayer(blurLayer, transaction);
+                    }
+
+                    @Override
+                    public void onAnimationCancel(Animator animation) {
+                        cleanupBlurLayer(blurLayer, transaction);
+                    }
+
+                    private void cleanupBlurLayer(SurfaceControl blurLayer, SurfaceControl.Transaction transaction) {
+                        if (blurLayer != null && blurLayer.isValid()) {
+                            transaction.remove(blurLayer).apply();
+                            blurLayer.release(); // Release the SurfaceControl to avoid leaks
+                        }
+                    }
+                });
+            }
+        }
+
+        backgroundRadiusAnim.addListener(
+                AnimatorListeners.forEndCallback(() -> {
+                    depthController.stateDepth
+                            .setValue(mLauncher.getDepthController().stateDepth.getValue());
+                    depthController.dispose();
+                }));
+
+        return backgroundRadiusAnim;
+    }
     /**
      * Registers remote animations used when closing apps to home screen.
      */

--- a/res/values/cr_strings.xml
+++ b/res/values/cr_strings.xml
@@ -478,4 +478,8 @@
     <string name="widget_data_title">Data widget</string>
     <string name="widget_bt_title">Bluetooth widget</string>
     <string name="photo_widget_onboarding">Click to add new photo</string>
+
+    <!-- Background blur at app launch-->
+    <string name="pref_blur_background_at_app_launch_title">Background blur at app launch</string>
+    <string name="pref_blur_background_at_app_launch_summary">Blur the background at app launch</string>
 </resources>

--- a/res/xml/launcher_misc_preferences.xml
+++ b/res/xml/launcher_misc_preferences.xml
@@ -61,6 +61,15 @@
         <intent android:action="android.settings.ACTION_CONTENT_SUGGESTIONS_SETTINGS" />
     </androidx.preference.PreferenceScreen>
 
+    <SwitchPreferenceCompat
+        android:key="pref_blur_background_at_app_launch"
+        android:title="@string/pref_blur_background_at_app_launch_title"
+        android:summary="@string/pref_blur_background_at_app_launch_summary"
+        android:defaultValue="true"
+        android:persistent="true"
+        launcher:iconSpaceReserved="false"
+        android:layout="@layout/settings_layout_middle" />
+
     <com.android.launcher3.settings.preference.RestartPreference
         android:key="pref_restart"
         android:title="@string/pref_restart_title"

--- a/src/com/android/launcher3/Utilities.java
+++ b/src/com/android/launcher3/Utilities.java
@@ -207,7 +207,7 @@ public final class Utilities {
     public static final String KEY_DRAWER_SCROLLBAR = "pref_drawer_scrollbar";
     public static final String KEY_FORCE_MONOCHROME_ICON = "pref_force_monochrome_icon";
     public static final String KEY_AUTO_KEYABORD = "pref_auto_keyboard";
-
+    public static final String KEY_BLUR_BACKGROUND_AT_APP_LAUNCH = "pref_blur_background_at_app_launch";
     /**
      * Returns true if theme is dark.
      */
@@ -1221,7 +1221,12 @@ public final class Utilities {
         SharedPreferences prefs = LauncherPrefs.getPrefs(context.getApplicationContext());
         return prefs.getBoolean(KEY_AUTO_KEYABORD, false);
     }
-    
+
+    public static boolean blurBackgroundAtAppLaunch(Context context) {
+        SharedPreferences prefs = LauncherPrefs.getPrefs(context.getApplicationContext());
+        return prefs.getBoolean(KEY_BLUR_BACKGROUND_AT_APP_LAUNCH, true);
+    }
+
     public static boolean startContextualSearch(Context context, int entrypoint) {
         Context appContext = context.getApplicationContext();
         ContextualSearchManager contextualSearchManager = 


### PR DESCRIPTION
Add an option to enable/disable background blur at app launch

![Screenshot_20250125-175604_Ortus Launcher](https://github.com/user-attachments/assets/5ce4b3a2-15c1-402c-b492-59b70295ee08)
![Screenshot_20250125-175555_Settings](https://github.com/user-attachments/assets/6774748d-eac0-4781-a41a-bfa5305b556c)
I enabled it by default because it also works smoothly on snapdragon 845.